### PR TITLE
Feat: 가져올 채보 정보를 유니티로 전송

### DIFF
--- a/src/api/auth/logout.ts
+++ b/src/api/auth/logout.ts
@@ -1,3 +1,4 @@
+import { IAuthRes } from ".";
 import fetchExtended from "../fetchExtended";
 import { parseJsonWithWrap } from "../utils";
 

--- a/src/api/pattern_practice/getOne.ts
+++ b/src/api/pattern_practice/getOne.ts
@@ -4,7 +4,7 @@ import { parseJsonWithWrap } from "../utils";
 
 /**
  *
- * @param id level test id
+ * @param id pattern practice id
  * @returns
  */
 const getOne = async (id: number): Promise<{ data: IPatternPracticeRes }> => {

--- a/src/api/wiki/index.ts
+++ b/src/api/wiki/index.ts
@@ -25,7 +25,7 @@ export interface IWikiRes {
   [type: string]: number | IWiki[];
 }
 
-const PatternPracticeAPI = {
+const WikiAPI = {
   create,
   getAll,
   getOne,
@@ -33,4 +33,4 @@ const PatternPracticeAPI = {
   deleteOne,
 };
 
-export default PatternPracticeAPI;
+export default WikiAPI;

--- a/src/components/public/organisms/UnityContainer/UnityContainer.tsx
+++ b/src/components/public/organisms/UnityContainer/UnityContainer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import PatternPracticeAPI from "@/api/pattern_practice";
 import { setJudgeTime, setSpeed } from "@/lib/features/unity/unitySlice";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useRouter } from "next/navigation";
@@ -54,9 +53,12 @@ const UnityContainer = ({ id, category }: IUnityContainer) => {
   };
 
   const loadSheet = async () => {
-    const {
-      data: { title },
-    } = await PatternPracticeAPI.getOne(id);
+    // 추후 아래 주석의 코드로 변경
+    const title = "Splendid Circus";
+    // const {
+    //   data: { title },
+    // } = await PatternPracticeAPI.getOne(id);
+
     sendMessage("SheetLoader", "WebGLLoadSheet", title);
   };
 


### PR DESCRIPTION
### 💡 요약
<!-- 해당 PR에 대한 요약 -->
1. 가져올 채보 정보를 유니티로 전송

<br />

### 🙌 공유 파일 작업 내용
<!-- [Prefix] -->
<!-- PC: Public Component 관련 작업 시 -->
<!-- HK: Custom Hook 관련 작업 시 -->
<!-- API: API 모듈 관련 작업 시 -->
<!-- ETC: 이외의 파일 작업 시 -->
<!-- 필요시, 이외에도 Convention 추가 -->

<!-- [Suffix] -->
<!-- /C: 파일 추가 -->
<!-- /U: 파일 수정 -->
<!-- /D: 파일 삭제 -->

<!-- [EXAMPLE] -->
<!-- PC/C: CustomImage 추가 -->

- API/U: Wiki API의 export가 PatternPractice API로 되어있던 문제 수정
- PC/U: UnityContainer에서, 현재 페이지의 채보 제목을 유니티로 전송
- PC/U: UnityContainer에서, API 사용이 어려워, 채보 제목을 더미데이터로 임시 대체

<br />

### 👀 관련 이슈
<!-- #{이슈_번호} -->

#34 

<br />

--------------------------------------------------------------------------
### 📋 Pull Request 전 확인 사항
<!-- [ ] => 빈 체크박스 -->
<!-- [x] => 체크박스 -->

- [x] "yarn test"를 실행하여 테스트가 통과하는가?
- [ ] 컴포넌트를 만들었는가?
  - [ ] 해당 컴포넌트의 스토리를 작성했는가?
  - [ ] "yarn storybook"를 실행하여 개발서버가 실행되는가? 
