### PR TITLE
Feat: 유니티와 연계하여 키 설정 유저 커스텀 기능 구현

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,7 +6,7 @@ import { RouteChangesProvider } from "nextjs-router-events";
 
 const preview: Preview = {
   parameters: {
-    actions: { argTypesRegex: "^on[A-Z].*" },
+    actions: { argTypesRegex: "^(on[A-Z].*|set[A-Z].*)" },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/src/app/level_tests/page.tsx
+++ b/src/app/level_tests/page.tsx
@@ -10,7 +10,7 @@ const RhythmLevelTests = async () => {
   return (
     <FullScreenSection direction="col" className="bg-orange-100" asMainTag>
       {lists.map((list) => (
-        <p key={list.testId}>{list.title}</p>
+        <p key={list.id}>{list.title}</p>
       ))}
       <div className="flex w-full h-full justify-evenly items-center">
         <LevelCards />

--- a/src/app/my_page/page.tsx
+++ b/src/app/my_page/page.tsx
@@ -17,6 +17,7 @@ import CustomImage from "../../components/public/atoms/CustomImage/CustomImage";
 import useInput from "@/hooks/useInput";
 import Checkbox from "@/components/public/atoms/Checkbox/Checkbox";
 import AuthAPI from "@/api/auth";
+import KeySetting from "@/components/my_page/molecules/KeySetting/KeySetting";
 
 const MyPage = () => {
   // Input Management
@@ -59,15 +60,24 @@ const MyPage = () => {
   const [plateChingoSettings, setPlateChinghoSettings] = useState<IChingho>({
     rank: 1,
     children: "디맥 플레이어",
+    visibleChingho,
+    visibleChinghoIcon,
   });
 
   const changePlateChingho = (rank: TChinghoRank, children: ReactNode) => {
     setPlateChinghoSettings({ rank, children });
   };
 
+  // Game Key Settings Management
+  const [keyNum, setKeyNum] = useState<4 | 5 | 6>(4);
+  const [keySettingState, setKeySettingState] = useState<
+    "init" | "started" | "finished"
+  >("init");
+
   // Sidebar Shortcut
   const accountSettingRef = useRef<HTMLTableSectionElement>(null);
   const plateSettingRef = useRef<HTMLTableSectionElement>(null);
+  const gameSettingRef = useRef<HTMLTableSectionElement>(null);
 
   const moveToSettingSectionByRef = (
     ref: RefObject<HTMLTableSectionElement>,
@@ -104,6 +114,7 @@ const MyPage = () => {
                 </button>
                 <button
                   type="button"
+                  onClick={() => moveToSettingSectionByRef(gameSettingRef)}
                   className="w-full py-3 rounded-lg text-left hover:text-rose-400 transition-all"
                 >
                   게임 설정
@@ -114,10 +125,12 @@ const MyPage = () => {
           <button
             type="button"
             className="py-6 bg-blue-400 rounded-3xl text-white"
-            onClick={()=>AuthAPI.login({
-              username: "",
-              password: ""
-            })}
+            onClick={() =>
+              AuthAPI.login({
+                username: "",
+                password: "",
+              })
+            }
           >
             임시 로그인 버튼
           </button>
@@ -267,6 +280,17 @@ const MyPage = () => {
                 value="칭호 아이콘"
                 checked={visibleChinghoIcon}
                 onChange={changeVisibleChinghoIcon}
+              />
+            </SettingElem>
+          </SettingSection>
+
+          <SettingSection ref={gameSettingRef} title="게임 설정">
+            <SettingElem title="키 설정">
+              <KeySetting
+                keyNum={keyNum}
+                setKeyNum={setKeyNum}
+                state={keySettingState}
+                setState={setKeySettingState}
               />
             </SettingElem>
           </SettingSection>

--- a/src/app/pattern_practice/[practiceId]/page.tsx
+++ b/src/app/pattern_practice/[practiceId]/page.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import UnityContainer from "@/components/public/organisms/UnityContainer/UnityContainer";
+import { useAppSelector } from "@/lib/hooks";
+import Link from "next/link";
 
 interface IPatternPracticeFromPracticeId {
   params: {
@@ -9,9 +13,22 @@ interface IPatternPracticeFromPracticeId {
 const PatternPracticeFromPracticeId = ({
   params: { practiceId },
 }: IPatternPracticeFromPracticeId) => {
+  const { keyNum } = useAppSelector((state) => state.practice);
   return (
-    <main className="w-screen max-w-7xl mx-auto mt-10 text-center relative">
-      <UnityContainer category="pattern_practice" id={practiceId} />
+    <main className="flex flex-col items-center w-full mt-10 relative">
+      <UnityContainer
+        category="pattern_practice"
+        id={practiceId}
+        keyNum={keyNum}
+      />
+      <section className="flex flex-col w-2/3 mt-10">
+        <Link
+          href={"/my_page"}
+          className="w-32 py-2 text-center bg-blue-400 text-white rounded-full"
+        >
+          키 설정 변경
+        </Link>
+      </section>
     </main>
   );
 };

--- a/src/app/pattern_practice/page.tsx
+++ b/src/app/pattern_practice/page.tsx
@@ -28,9 +28,9 @@ const PatternPractice = () => {
   return (
     <MainSectionWithBothSideAds sectionTitle="패턴 연습">
       <CategoryWrapper>
-        <CategoryBtn value="4키" />
-        <CategoryBtn value="5키" />
-        <CategoryBtn value="6키" />
+        <CategoryBtn value={4} />
+        <CategoryBtn value={5} />
+        <CategoryBtn value={6} />
       </CategoryWrapper>
       <div className="flex justify-between w-full text-black mt-3">
         <div className="flex gap-5">

--- a/src/components/my_page/atoms/KeySettingElem/KeySettingElem.stories.tsx
+++ b/src/components/my_page/atoms/KeySettingElem/KeySettingElem.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import CategoryBtn from "./CategoryBtn";
+import KeySettingElem from "./KeySettingElem";
 
 const meta = {
-  title: "CategoryBtn",
-  component: CategoryBtn,
+  title: "KeySettingElem",
+  component: KeySettingElem,
   args: {
-    value: 4,
+    value: "a",
   },
-} satisfies Meta<typeof CategoryBtn>;
+} satisfies Meta<typeof KeySettingElem>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/my_page/atoms/KeySettingElem/KeySettingElem.tsx
+++ b/src/components/my_page/atoms/KeySettingElem/KeySettingElem.tsx
@@ -1,0 +1,13 @@
+interface IKeySettingElem {
+  value: string;
+}
+
+const KeySettingElem = ({ value }: IKeySettingElem) => {
+  return (
+    <div className="flex justify-center items-center w-20 h-20 bg-neutral-100 rounded-lg shadow-md border-2">
+      <span>{value}</span>
+    </div>
+  );
+};
+
+export default KeySettingElem;

--- a/src/components/my_page/molecules/KeySetting/KeySetting.stories.tsx
+++ b/src/components/my_page/molecules/KeySetting/KeySetting.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import KeySetting from "./KeySetting";
+import { fn } from "@storybook/test";
+
+const meta = {
+  title: "KeySetting",
+  component: KeySetting,
+  args: {
+    keyNum: 4,
+    setKeyNum: fn(),
+    state: "init",
+    setState: fn(),
+  },
+} satisfies Meta<typeof KeySetting>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/my_page/molecules/KeySetting/KeySetting.tsx
+++ b/src/components/my_page/molecules/KeySetting/KeySetting.tsx
@@ -1,0 +1,130 @@
+import {
+  Dispatch,
+  KeyboardEvent as ReactKeyboardEvent,
+  SetStateAction,
+} from "react";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import {
+  setFiveKeyMaps,
+  setFourKeyMaps,
+  setSixKeyMaps,
+} from "@/lib/features/unity/unitySlice";
+import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
+import KeySettingElem from "../../atoms/KeySettingElem/KeySettingElem";
+
+interface IKeySetting {
+  keyNum: number;
+  setKeyNum: Dispatch<SetStateAction<4 | 5 | 6>>;
+  state: "init" | "started" | "finished";
+  setState: Dispatch<SetStateAction<"init" | "started" | "finished">>;
+}
+
+const KeySetting = ({ keyNum, setKeyNum, state, setState }: IKeySetting) => {
+  const dispatch = useAppDispatch();
+
+  let setLocalKeyMaps: ActionCreatorWithPayload<string[], any>;
+  const localKeyMaps = useAppSelector((state) => {
+    if (keyNum === 4) {
+      setLocalKeyMaps = setFourKeyMaps;
+      return state.unity.fourKeyMaps;
+    } else if (keyNum === 5) {
+      setLocalKeyMaps = setFiveKeyMaps;
+      return state.unity.fiveKeyMaps;
+    } else if (keyNum === 6) {
+      setLocalKeyMaps = setSixKeyMaps;
+      return state.unity.sixKeyMaps;
+    } else return [""];
+  });
+
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (state === "finished") return;
+
+    let value = e.key;
+    let newKeyMaps = [...localKeyMaps];
+    const changeIdx = newKeyMaps.indexOf("");
+
+    // 쉬프트 키의 경우
+    if (e.shiftKey) {
+      if (e.nativeEvent.location === KeyboardEvent.DOM_KEY_LOCATION_LEFT) {
+        value = "LeftShift";
+      } else if (
+        e.nativeEvent.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT
+      ) {
+        value = "RightShift";
+      }
+    }
+    // 스페이스바의 경우
+    else if (e.key === " ") {
+      value = "Space";
+    }
+
+    newKeyMaps[changeIdx] = value;
+    dispatch(setLocalKeyMaps(newKeyMaps));
+
+    // 마지막 입력일 경우
+    if (localKeyMaps.length == changeIdx + 1) {
+      setState("finished");
+    }
+  };
+
+  const modifyKeys = () => {
+    setState("started");
+    dispatch(
+      setLocalKeyMaps(Array(keyNum === 5 ? keyNum + 1 : keyNum).fill("")),
+    );
+  };
+  return (
+    <div className="flex flex-col gap-10">
+      {/** 키 선택 */}
+      <div className="flex h-14 bg-neutral-100 shadow-md rounded-full">
+        <button
+          className={`w-full py-1 text-lg ${keyNum === 4 && "text-rose-400"}`}
+          onClick={() => setKeyNum(4)}
+        >
+          4키
+        </button>
+        <button
+          className={`w-full py-1 text-lg ${keyNum === 5 && "text-rose-400"}`}
+          onClick={() => setKeyNum(5)}
+        >
+          5키
+        </button>
+        <button
+          className={`w-full py-1 text-lg ${keyNum === 6 && "text-rose-400"}`}
+          onClick={() => setKeyNum(6)}
+        >
+          6키
+        </button>
+      </div>
+
+      {/** 현재 설정된 조작키 */}
+      <div className="flex justify-center w-full gap-10">
+        {localKeyMaps.map((key, idx) => (
+          <KeySettingElem key={idx} value={key} />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={modifyKeys}
+        onKeyDown={onKeyDown}
+        className="w-1/2 h-14 mx-auto bg-blue-400 text-white rounded-full text-lg outline-none"
+      >
+        재설정
+      </button>
+
+      <p className="mx-auto">
+        {state === "init"
+          ? "재설정 버튼을 누르고, 사용할 조작키를 차례대로 눌러주세요!"
+          : state === "started"
+          ? `진행도: ${localKeyMaps.indexOf("")}개 설정 / ${
+              keyNum === 5 ? keyNum + 1 : keyNum
+            }개`
+          : "재설정이 정상적으로 완료되었습니다!"}
+      </p>
+    </div>
+  );
+};
+
+export default KeySetting;

--- a/src/components/my_page/molecules/PlateChinghoListByRank/PlateChinghoListByRank.tsx
+++ b/src/components/my_page/molecules/PlateChinghoListByRank/PlateChinghoListByRank.tsx
@@ -24,6 +24,7 @@ const rank2Chinghos = [
 ];
 const rank3Chinghos = ["능동적인 디맥 리게이", "능동적인 이지투 리게이"];
 const rank4Chinghos = ["사볼 악귀"];
+
 const PlateChinghoListByRank = ({ rank, onClick }: IPlateChinghoList) => {
   return (
     <div className="my-8">

--- a/src/components/pattern_practice/atoms/CategoryBtn/CategoryBtn.tsx
+++ b/src/components/pattern_practice/atoms/CategoryBtn/CategoryBtn.tsx
@@ -1,26 +1,26 @@
-import { setKeyName } from "@/lib/features/practice/practiceSlice";
+import { setKeyNum } from "@/lib/features/practice/practiceSlice";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 
 interface ICategoryBtn {
-  value: string;
+  value: number;
 }
 
 const CategoryBtn = ({ value }: ICategoryBtn) => {
-  const { keyName } = useAppSelector((state) => state.practice);
+  const { keyNum } = useAppSelector((state) => state.practice);
   const dispatch = useAppDispatch();
 
   return (
     <div
       className="flex justify-center first:mx-10 mr-10"
-      onClick={() => dispatch(setKeyName(value))}
+      onClick={() => dispatch(setKeyNum(value))}
     >
       <button
         type="button"
         className={`w-20 py-1 border-rose-400 ${
-          keyName === value && "border-b-4"
+          keyNum === value && "border-b-4"
         }`}
       >
-        {value}
+        {value}키
       </button>
     </div>
   );

--- a/src/components/pattern_practice/atoms/CategoryWrapper/CategoryWrapper.stories.tsx
+++ b/src/components/pattern_practice/atoms/CategoryWrapper/CategoryWrapper.stories.tsx
@@ -8,9 +8,9 @@ const meta = {
   args: {
     children: (
       <>
-        <CategoryBtn value="4키" />
-        <CategoryBtn value="5키" />
-        <CategoryBtn value="6키" />
+        <CategoryBtn value={4} />
+        <CategoryBtn value={5} />
+        <CategoryBtn value={6} />
       </>
     ),
   },

--- a/src/components/public/organisms/UnityContainer/UnityContainer.stories.tsx
+++ b/src/components/public/organisms/UnityContainer/UnityContainer.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   args: {
     category: "level_tests",
     id: 1,
+    keyNum: 4,
   },
 } satisfies Meta<typeof UnityContainer>;
 

--- a/src/components/public/organisms/UnityContainer/UnityContainer.tsx
+++ b/src/components/public/organisms/UnityContainer/UnityContainer.tsx
@@ -29,10 +29,10 @@ const UnityContainer = ({ id, category, keyNum }: IUnityContainer) => {
     unload,
     isLoaded,
   } = useUnityContext({
-    loaderUrl: `/unity/build/Build/build.loader.js`,
-    dataUrl: `/unity/build/Build/build.data`,
-    frameworkUrl: `/unity/build/Build/build.framework.js`,
-    codeUrl: `/unity/build/Build/build.wasm`,
+    loaderUrl: `${CLOUDFRONT_URL}/unity/build/Build/build.loader.js`,
+    dataUrl: `${CLOUDFRONT_URL}/unity/build/Build/build.data`,
+    frameworkUrl: `${CLOUDFRONT_URL}/unity/build/Build/build.framework.js`,
+    codeUrl: `${CLOUDFRONT_URL}/unity/build/Build/build.wasm`,
   });
 
   const unloadRef = useRef<() => void>();

--- a/src/lib/features/practice/practiceSlice.ts
+++ b/src/lib/features/practice/practiceSlice.ts
@@ -2,14 +2,14 @@ import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
 interface PracticeState {
-  keyName: string;
+  keyNum: number;
   filterItems: string[];
   dropdownType: string;
   sortType: string;
 }
 
 const initialState: PracticeState = {
-  keyName: "4키",
+  keyNum: 4,
   filterItems: [],
   dropdownType: "",
   sortType: "클리어 레이트순",
@@ -19,10 +19,10 @@ const practiceSlice = createSlice({
   name: "practice",
   initialState,
   reducers: {
-    setKeyName(state, action: PayloadAction<string>) {
-      state.keyName = action.payload;
+    setKeyNum(state, action: PayloadAction<typeof state.keyNum>) {
+      state.keyNum = action.payload;
     },
-    setSortType(state, action: PayloadAction<string>) {
+    setSortType(state, action: PayloadAction<typeof state.sortType>) {
       state.sortType = action.payload;
     },
     toggleFilterItems(state, action: PayloadAction<string>) {
@@ -42,11 +42,7 @@ const practiceSlice = createSlice({
   },
 });
 
-export const {
-  setKeyName,
-  setSortType,
-  toggleFilterItems,
-  toggleDropdownType,
-} = practiceSlice.actions;
+export const { setKeyNum, setSortType, toggleFilterItems, toggleDropdownType } =
+  practiceSlice.actions;
 
 export default practiceSlice.reducer;

--- a/src/lib/features/unity/unitySlice.ts
+++ b/src/lib/features/unity/unitySlice.ts
@@ -4,11 +4,17 @@ import type { PayloadAction } from "@reduxjs/toolkit";
 interface UnityState {
   speed: number;
   judgeTime: number;
+  fourKeyMaps: string[];
+  fiveKeyMaps: string[];
+  sixKeyMaps: string[];
 }
 
 const initialState: UnityState = {
   speed: 1.0,
   judgeTime: 0,
+  fourKeyMaps: ["a", "s", "d", ";", "'"],
+  fiveKeyMaps: ["a", "s", "d", "l", ";", "'"],
+  sixKeyMaps: ["a", "s", "d", ";", "l", "'"],
 };
 
 const unitySlice = createSlice({
@@ -21,9 +27,24 @@ const unitySlice = createSlice({
     setJudgeTime(state, action: PayloadAction<typeof state.judgeTime>) {
       state.judgeTime = action.payload;
     },
+    setFourKeyMaps(state, action: PayloadAction<typeof state.fourKeyMaps>) {
+      state.fourKeyMaps = action.payload;
+    },
+    setFiveKeyMaps(state, action: PayloadAction<typeof state.fiveKeyMaps>) {
+      state.fiveKeyMaps = action.payload;
+    },
+    setSixKeyMaps(state, action: PayloadAction<typeof state.sixKeyMaps>) {
+      state.sixKeyMaps = action.payload;
+    },
   },
 });
 
-export const { setSpeed, setJudgeTime } = unitySlice.actions;
+export const {
+  setSpeed,
+  setJudgeTime,
+  setFourKeyMaps,
+  setFiveKeyMaps,
+  setSixKeyMaps,
+} = unitySlice.actions;
 
 export default unitySlice.reducer;


### PR DESCRIPTION
### 💡 요약
<!-- 해당 PR에 대한 요약 -->
1. 플레이트 표시 설정이 플레이트 미리보기에 적용되지 않던 버그 수정
2. 마이페이지, 게임 설정 - 키 설정 구현 완료

<br />

### 🙌 공유 파일 작업 내용
<!-- [Prefix] -->
<!-- PC: Public Component 관련 작업 시 -->
<!-- HK: Custom Hook 관련 작업 시 -->
<!-- API: API 모듈 관련 작업 시 -->
<!-- ETC: 이외의 파일 작업 시 -->
<!-- 필요시, 이외에도 Convention 추가 -->

<!-- [Suffix] -->
<!-- /C: 파일 추가 -->
<!-- /U: 파일 수정 -->
<!-- /D: 파일 삭제 -->

<!-- [EXAMPLE] -->
<!-- PC/C: CustomImage 추가 -->

- RDX/U: UnitySlice에 4키, 5키, 6키에 해당하는 각각의 키 매핑 State 추가

<br />

### 👀 관련 이슈
<!-- #{이슈_번호} -->

#36 

<br />

--------------------------------------------------------------------------
### 📋 Pull Request 전 확인 사항
<!-- [ ] => 빈 체크박스 -->
<!-- [x] => 체크박스 -->

- [x] "yarn test"를 실행하여 테스트가 통과하는가?
- [x] 컴포넌트를 만들었는가?
  - [x] 해당 컴포넌트의 스토리를 작성했는가?
  - [x] "yarn storybook"를 실행하여 개발서버가 실행되는가? 
