### PR TITLE
Fix: 유니티 단축키를 눌렀을 때, 컴포넌트가 재로딩되는 버그 수정

### DIFF
--- a/src/components/organisms/UnityContainer/UnityContainer.tsx
+++ b/src/components/organisms/UnityContainer/UnityContainer.tsx
@@ -107,41 +107,6 @@ const UnityContainer = ({ id, referer }: IUnityContainer) => {
   }, [initUserState, isLoaded, loadSheet]);
   /** END Send User Setting To Unity */
 
-  /** Set Speed, JudgeTime From Unity */
-  const handleSetSpeed = useCallback(
-    (speed: ReactUnityEventParameter) => {
-      if (typeof speed === "string") {
-        dispatch(setSpeed(parseFloat(speed)));
-      }
-    },
-    [dispatch],
-  );
-
-  const handleSetJudgeOffset = useCallback(
-    (offset: ReactUnityEventParameter) => {
-      if (typeof offset === "number") {
-        dispatch(setJudgeOffset(offset));
-      }
-    },
-    [dispatch],
-  );
-
-  useEffect(() => {
-    addEventListener("SetSpeed", handleSetSpeed);
-    addEventListener("SetJudgeOffset", handleSetJudgeOffset);
-    return () => {
-      removeEventListener("SetSpeed", handleSetSpeed);
-      removeEventListener("SetJudgeOffset", handleSetJudgeOffset);
-    };
-  }, [
-    addEventListener,
-    removeEventListener,
-    handleSetSpeed,
-    handleSetJudgeOffset,
-    isLoaded,
-  ]);
-  /** END Set Speed, JudgeTime From Unity */
-
   /** Prevent WebGL Canvas Unmount Error */
   useRouteChangeEvents({
     onBeforeRouteChange: () => {


### PR DESCRIPTION
### 💡 요약

<!-- 해당 PR에 대한 요약 -->

1. [Fix: 유니티 단축키를 눌렀을 때, 컴포넌트가 재로딩되는 버그 수정](https://github.com/rhythm-gamers/rg-front/commit/9975639604a90e4e5c4000c144501674e3ad8f7b)

<br />

### 🙌 공유 파일 작업 내용

<!-- [Prefix] -->
<!-- PC: Public Component 관련 작업 시 -->
<!-- HK: Custom Hook 관련 작업 시 -->
<!-- API: API 모듈 관련 작업 시 -->
<!-- RDX: Redux 관련 작업 시 -->
<!-- ETC: 이외의 파일 작업 시 -->
<!-- 필요시, 이외에도 Convention 추가 -->

<!-- [Suffix] -->
<!-- /C: 파일 추가 -->
<!-- /U: 파일 수정 -->
<!-- /D: 파일 삭제 -->

<!-- [EXAMPLE] -->
<!-- PC/C: CustomImage 추가 -->


<br />

### 👀 관련 이슈

<!-- #{이슈_번호} -->

#85 

<br />

---

### 📋 Pull Request 전 확인 사항

<!-- [ ] => 빈 체크박스 -->
<!-- [x] => 체크박스 -->

- [ ] 컴포넌트를 만들었는가?
  - [ ] 해당 컴포넌트의 스토리를 작성했는가?
  - [ ] "yarn storybook"를 실행하여 개발서버가 실행되는가?
